### PR TITLE
fix(apiv2): remove dynamic api prefix from runtime transports

### DIFF
--- a/apiv2/transport/rest-client.go
+++ b/apiv2/transport/rest-client.go
@@ -18,7 +18,7 @@ func GetRuntimeTransport(context context.Context, currConfig *apiv2.SdkConfig) (
 		return nil, e
 	}
 
-	tp := client.New(u.Host, getApiPrefix(currConfig), []string{u.Scheme})
+	tp := client.New(u.Host, CellsApiPrefix, []string{u.Scheme})
 	transportOptions := []any{
 		WithSkipVerify(currConfig.SkipVerify),
 		WithCustomHeaders(currConfig.CustomHeaders),
@@ -42,7 +42,7 @@ func GetClientTransport(currConfig *apiv2.SdkConfig, anonymous bool) (runtime.Cl
 		return nil, e
 	}
 
-	tp := client.New(u.Host, getApiPrefix(currConfig), []string{u.Scheme})
+	tp := client.New(u.Host, CellsApiPrefix, []string{u.Scheme})
 	options := []any{
 		WithSkipVerify(currConfig.SkipVerify),
 		WithCustomHeaders(currConfig.CustomHeaders),
@@ -59,12 +59,3 @@ func GetClientTransport(currConfig *apiv2.SdkConfig, anonymous bool) (runtime.Cl
 
 	return tp, nil
 }
-
-// getApiPrefix always uses the default CellsApiPrefix for runtime transports.
-func getApiPrefix(currConfig *apiv2.SdkConfig) string {
-	if currConfig.ApiResourcePrefix != "" {
-		return currConfig.ApiResourcePrefix
-	}
-	return CellsApiPrefix
-}
-


### PR DESCRIPTION
This commit removes the dynamic API prefix configuration for runtime transports, using the default CellsApiPrefix instead.

Detailed Changes:
 - Implementation:
   - Changed rest-client.go to use CellsApiPrefix directly in GetRuntimeTransport and GetClientTransport.
   - Removed the getApiPrefix function that previously selected the prefix based on config.


Since the prefix api is mostly used for the v1 api, I think adding to the v2 would just cause confusion.
